### PR TITLE
Build issue with gcc 5.3.1

### DIFF
--- a/src/HTTPIO.cpp
+++ b/src/HTTPIO.cpp
@@ -71,8 +71,7 @@ Poco::Net::HTTPClientSession* doHTTPIO(const Poco::URI& uri,
 
   //write request body
   ostream &ostream = session->sendRequest(request);
-  if (ostream == nullptr)
-    return nullptr;
+
   ostream << reqBody;
   return session;
 }
@@ -100,8 +99,7 @@ Poco::Net::HTTPClientSession* doHTTPIO(const Poco::URI& uri,
 
   //write request body
   ostream &ostream = session->sendRequest(request);
-  if (ostream == nullptr)
-    return nullptr;
+
   ostream << reqBody;
   return session;
 }


### PR DESCRIPTION
gcc 5.3.1 fails to build:

```
src/HTTPIO.cpp: In function ‘Poco::Net::HTTPClientSession* Swift::doHTTPIO(const Poco::URI&, const string&, std::vector<Swift::HTTPHeader>*, const char*, ulong, const string&)’:
src/HTTPIO.cpp:103:15: error: no match for ‘operator==’ (operand types are ‘std::ostream {aka std::basic_ostream<char>}’ and ‘std::nullptr_t’)
   if (ostream == nullptr)
               ^
In file included from /usr/include/c++/5/stack:61:0,
                 from src/json.h:1526,
                 from src/Tenant.h:24,
                 from src/Token.h:23,
                 from src/Account.h:23,
                 from src/HTTPIO.h:36,
                 from src/HTTPIO.cpp:20:
/usr/include/c++/5/bits/stl_stack.h:246:5: note: candidate: template<class _Tp, class _Seq> bool std::operator==(const std::stack<_Tp, _Seq>&, const std::stack<_Tp, _Seq>&)
     operator==(const stack<_Tp, _Seq>& __x, const stack<_Tp, _Seq>& __y
```

The check might be unneeded - [see this stackoverflow thread](http://stackoverflow.com/questions/2524870/why-dont-i-need-to-check-if-references-are-invalid-null), and the [reference page](http://en.cppreference.com/w/cpp/language/reference).
